### PR TITLE
Animate projects title underline on hover

### DIFF
--- a/docs/superpowers/plans/2026-06-09-animation-redesign.md
+++ b/docs/superpowers/plans/2026-06-09-animation-redesign.md
@@ -1,0 +1,978 @@
+# Animation Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the site's clunky hand-rolled animations with a refined motion system (instant typewriter hero, blur fade-up scroll reveals, editorial hovers) while keeping layout, content, and colors unchanged.
+
+**Architecture:** Hybrid system — the `motion` library (Framer Motion successor) drives entrances and scroll reveals via shared variants in `src/motion.ts`; hover states stay pure CSS. One easing curve (`cubic-bezier(0.22, 1, 0.36, 1)`) everywhere. `MotionConfig reducedMotion="user"` + a CSS media query provide reduced-motion support.
+
+**Tech Stack:** React 18, TypeScript, Vite 5, `motion` (new dependency), plain CSS in `src/css/main.css`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-animation-redesign-design.md`
+
+**Note on verification:** This repo has no test framework, and the changes are visual. Each task is verified with `npm run build` (must compile) and a visual check in `npm run dev`. Do not introduce a test framework.
+
+---
+
+### Task 1: Install `motion` and create shared animation tokens
+
+**Files:**
+- Modify: `package.json` (via npm)
+- Create: `src/motion.ts`
+
+- [ ] **Step 1: Install the library**
+
+```bash
+npm install motion
+```
+
+Expected: `motion` appears in `package.json` dependencies (v12.x).
+
+- [ ] **Step 2: Create `src/motion.ts`**
+
+```ts
+import type { Variants } from 'motion/react';
+
+export const EASE_OUT_EXPO: [number, number, number, number] = [
+  0.22, 1, 0.36, 1,
+];
+
+export const blurFadeUp: Variants = {
+  hidden: { opacity: 0, y: 14, filter: 'blur(6px)' },
+  visible: (delay: number = 0) => ({
+    opacity: 1,
+    y: 0,
+    filter: 'blur(0px)',
+    transition: { duration: 0.5, ease: EASE_OUT_EXPO, delay },
+  }),
+};
+
+export const staggerContainer: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08 } },
+};
+
+export const lineDraw: Variants = {
+  hidden: { scaleY: 0 },
+  visible: {
+    scaleY: 1,
+    transition: { duration: 0.9, ease: EASE_OUT_EXPO },
+  },
+};
+
+export const VIEWPORT_ONCE = {
+  once: true,
+  margin: '0px 0px -60px 0px',
+} as const;
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: builds with no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json src/motion.ts
+git commit -m "chore: add motion library and shared animation tokens"
+```
+
+---
+
+### Task 2: Wrap app in MotionConfig and refine nav easing
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/css/main.css` (`.navbar` rule, ~line 101)
+
+- [ ] **Step 1: Wrap the app in `MotionConfig`**
+
+In `src/App.tsx`, add the import and wrap the returned tree:
+
+```tsx
+import { MotionConfig } from 'motion/react';
+```
+
+Change the return statement to:
+
+```tsx
+return (
+  <MotionConfig reducedMotion="user">
+    <div className="App">
+      <Navigation isVisible={isNavVisible} />
+      <Hero />
+      <About />
+      <Experiences />
+      <Projects />
+      <Footer />
+    </div>
+  </MotionConfig>
+);
+```
+
+Leave the scroll listener logic unchanged.
+
+- [ ] **Step 2: Update navbar transition in `src/css/main.css`**
+
+In the `.navbar` rule, replace:
+
+```css
+  transition:
+    all 0.3s ease,
+    transform 0.3s ease;
+```
+
+with:
+
+```css
+  transition:
+    transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 0.3s ease;
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build` → passes.
+Run: `npm run dev`, scroll down/up → navbar hides and shows with a smoother glide.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/App.tsx src/css/main.css
+git commit -m "feat: add MotionConfig and refine navbar easing"
+```
+
+---
+
+### Task 3: Create `Reveal` component and migrate About
+
+**Files:**
+- Create: `src/components/Reveal.tsx`
+- Modify: `src/components/About.tsx` (full rewrite, removes IntersectionObserver)
+
+- [ ] **Step 1: Create `src/components/Reveal.tsx`**
+
+```tsx
+import { ReactNode } from 'react';
+import { motion } from 'motion/react';
+import { blurFadeUp, VIEWPORT_ONCE } from '../motion';
+
+interface RevealProps {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+}
+
+const Reveal = ({ children, className, delay = 0 }: RevealProps) => (
+  <motion.div
+    className={className}
+    initial="hidden"
+    whileInView="visible"
+    viewport={VIEWPORT_ONCE}
+    variants={blurFadeUp}
+    custom={delay}
+  >
+    {children}
+  </motion.div>
+);
+
+export default Reveal;
+```
+
+- [ ] **Step 2: Rewrite `src/components/About.tsx`**
+
+Replace the entire file (the `useEffect`/`useRef`/IntersectionObserver code is deleted; content is unchanged):
+
+```tsx
+import Reveal from './Reveal';
+
+const About = () => {
+  return (
+    <section id="about" className="about">
+      <div className="container">
+        <h2 className="section-heading">about.</h2>
+        <Reveal className="about-content">
+          <p className="subheading">
+            I study computer science at the University of Pennsylvania School of
+            Engineering and Applied Science.
+          </p>
+          <p>
+            I have a <strong>strong engineering background</strong> and enjoy
+            chasing <strong>hard problems</strong>. I've led multiple projects
+            and have a strong grasp of the full software development lifecycle.
+          </p>
+          <p>
+            In college, I <span className="underline">push myself</span> across
+            diverse areas of computer science, including distributed systems,
+            machine learning, and systems programming.
+          </p>
+        </Reveal>
+      </div>
+    </section>
+  );
+};
+
+export default About;
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build` → passes.
+Run: `npm run dev`, scroll to About → content rises ~14px while sharpening from blur, once, no flicker on re-scroll.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Reveal.tsx src/components/About.tsx
+git commit -m "feat: add Reveal component and migrate About to blur fade-up"
+```
+
+---
+
+### Task 4: Rewrite the Hero entrance
+
+**Files:**
+- Modify: `src/components/Hero.tsx` (full rewrite of animation logic; JSX structure and content unchanged)
+- Modify: `src/css/main.css` (hero rules, ~lines 184–341)
+
+- [ ] **Step 1: Rewrite `src/components/Hero.tsx`**
+
+Replace the entire file:
+
+```tsx
+import { useState, useEffect } from 'react';
+import { motion, useReducedMotion } from 'motion/react';
+import headshotImage from '../assets/headshot.png';
+import { blurFadeUp } from '../motion';
+
+interface SocialLink {
+  href: string;
+  icon: string;
+  label: string;
+}
+
+const LINE1 = 'Hey,';
+const LINE2 = "I'm ";
+const NAME = 'Nathan';
+const TYPING_SPEED_MS = 55;
+
+type TypingPhase = 'line1' | 'line2' | 'name' | 'done';
+
+const Hero = () => {
+  const [line1, setLine1] = useState<string>('');
+  const [line2, setLine2] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const [phase, setPhase] = useState<TypingPhase>('line1');
+  const prefersReducedMotion = useReducedMotion();
+
+  const socialLinks: SocialLink[] = [
+    {
+      href: 'https://linkedin.com/in/nathanaronson',
+      icon: 'fab fa-linkedin-in',
+      label: 'LinkedIn',
+    },
+    {
+      href: 'https://github.com/nathanaronson',
+      icon: 'fab fa-github',
+      label: 'GitHub',
+    },
+    {
+      href: 'mailto:narons@seas.upenn.edu',
+      icon: 'fas fa-envelope',
+      label: 'Email',
+    },
+  ];
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setLine1(LINE1);
+      setLine2(LINE2);
+      setName(NAME);
+      setPhase('done');
+      return;
+    }
+
+    let cancelled = false;
+
+    const type = (
+      text: string,
+      setText: (value: string) => void
+    ): Promise<void> =>
+      new Promise(resolve => {
+        let i = 0;
+        const timer = setInterval(() => {
+          if (cancelled) {
+            clearInterval(timer);
+            return;
+          }
+          i++;
+          setText(text.substring(0, i));
+          if (i >= text.length) {
+            clearInterval(timer);
+            resolve();
+          }
+        }, TYPING_SPEED_MS);
+      });
+
+    const run = async (): Promise<void> => {
+      await type(LINE1, setLine1);
+      if (cancelled) return;
+      setPhase('line2');
+      await type(LINE2, setLine2);
+      if (cancelled) return;
+      setPhase('name');
+      await type(NAME, setName);
+      if (cancelled) return;
+      setTimeout(() => {
+        if (!cancelled) setPhase('done');
+      }, 600);
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [prefersReducedMotion]);
+
+  const scrollToAbout = (): void => {
+    const aboutSection = document.querySelector('#about');
+    if (aboutSection) {
+      aboutSection.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }
+  };
+
+  return (
+    <section id="hero" className="hero">
+      <div className="container">
+        <div className="hero-content">
+          <div className="hero-left">
+            <motion.div
+              className="profile-image"
+              initial="hidden"
+              animate="visible"
+              variants={blurFadeUp}
+              custom={0.1}
+            >
+              <img src={headshotImage} alt="Nathan Aronson" />
+            </motion.div>
+          </div>
+
+          <div className="hero-right">
+            <div className="greeting">
+              <h1>
+                {line1}
+                {phase === 'line1' && <span className="cursor">|</span>}
+              </h1>
+              <h2>
+                {line2}
+                <span className="gradient-text">{name}</span>
+                {(phase === 'line2' || phase === 'name') && (
+                  <span className="cursor">|</span>
+                )}
+              </h2>
+            </div>
+
+            <motion.div
+              className="social-icons"
+              initial="hidden"
+              animate="visible"
+              variants={blurFadeUp}
+              custom={0.25}
+            >
+              {socialLinks.map(link => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className="social-icon"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={link.label}
+                >
+                  <i className={link.icon}></i>
+                </a>
+              ))}
+            </motion.div>
+
+            <motion.div
+              className="scroll-indicator"
+              onClick={scrollToAbout}
+              initial="hidden"
+              animate="visible"
+              variants={blurFadeUp}
+              custom={0.4}
+            >
+              <i className="fas fa-chevron-down"></i>
+            </motion.div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;
+```
+
+Key behavior: typing starts immediately on mount (cursor blinks on the empty `h1` from the first frame); `"Hey,I'm Nathan"` finishes in ~0.8s; the cursor disappears 600ms after typing completes; photo/icons/indicator animate in parallel rather than waiting.
+
+- [ ] **Step 2: Update hero CSS in `src/css/main.css`**
+
+Make these exact edits:
+
+In `.profile-image`, delete these three lines (Motion owns the entrance now):
+
+```css
+  opacity: 0;
+  transform: translateX(-100px);
+  animation: slideInLeft 1.2s ease forwards 2.25s;
+```
+
+Delete the whole `@keyframes slideInLeft { ... }` block.
+
+In `.greeting h1`, delete these two lines:
+
+```css
+  opacity: 0;
+  animation: fadeIn 1s ease forwards 0.3s;
+```
+
+(Keep the `@keyframes fadeIn` block for now — `.projects-toggle` still uses it until Task 6.)
+
+Delete this whole rule (the `typing-complete` class no longer exists):
+
+```css
+.greeting h1.typing-complete::after,
+.greeting h2.typing-complete::after {
+  display: none;
+}
+```
+
+In `.social-icons`, delete these three lines:
+
+```css
+  opacity: 0;
+  transform: translateX(100px);
+  animation: slideInRight 1.2s ease forwards 2.4s;
+```
+
+Delete the whole `@keyframes slideInRight { ... }` block.
+
+In `.social-icon`, replace `transition: all 0.3s ease;` with:
+
+```css
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
+```
+
+Replace the `.social-icon:hover` rule with (no more lift/scale):
+
+```css
+.social-icon:hover {
+  background-color: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+```
+
+In `.scroll-indicator`, delete these two lines:
+
+```css
+  opacity: 0;
+  animation: fadeIn 1s ease forwards 2.1s;
+```
+
+In `.scroll-indicator i`, change the animation to `animation: bounce 2.4s ease-in-out infinite;` and replace the whole `@keyframes bounce` block with:
+
+```css
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build` → passes.
+Run: `npm run dev` → on load: cursor appears instantly, typing finishes in under a second, photo/icons/scroll-indicator blur-fade in during the first half-second, gradient on "Nathan" intact, gentle slow bounce on the chevron. Social icon hover only brightens (no lift).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Hero.tsx src/css/main.css
+git commit -m "feat: refine hero with instant typewriter and parallel fades"
+```
+
+---
+
+### Task 5: Choreograph the Experiences timeline
+
+**Files:**
+- Modify: `src/components/Experiences.tsx` (delete IntersectionObserver `useEffect` + `useRef`, convert to Motion variant tree, add a real line element)
+- Modify: `src/css/main.css` (experiences rules, ~lines 387–460, plus media-query line rules)
+
+- [ ] **Step 1: Update `src/components/Experiences.tsx`**
+
+Change the imports at the top — remove `useEffect`/`useRef`, add Motion:
+
+```tsx
+import { motion } from 'motion/react';
+import {
+  blurFadeUp,
+  lineDraw,
+  staggerContainer,
+  VIEWPORT_ONCE,
+} from '../motion';
+```
+
+(Keep all the image imports and the `Experience` interface and `experiencesData` array exactly as they are.)
+
+Delete the entire `useEffect(() => { ... }, []);` block (lines 130–192 in the current file) and the `const experiencesRef = useRef<HTMLDivElement>(null);` line.
+
+Replace the returned JSX's container portion. The outer `<section>`, heading, and subheading stay identical. Change:
+
+```tsx
+<div className="experiences-container" ref={experiencesRef}>
+  {experiencesData.map(item => (
+    <div key={item.id} className="experiences-item">
+```
+
+to:
+
+```tsx
+<motion.div
+  className="experiences-container"
+  initial="hidden"
+  whileInView="visible"
+  viewport={VIEWPORT_ONCE}
+  variants={staggerContainer}
+>
+  <motion.div className="experiences-line" variants={lineDraw} />
+  {experiencesData.map(item => (
+    <motion.div
+      key={item.id}
+      className="experiences-item"
+      variants={blurFadeUp}
+    >
+```
+
+and close with `</motion.div>` for both the item and the container. Everything inside each item (`experiences-icon`, `experiences-content`, the skills/items markup) is unchanged.
+
+- [ ] **Step 2: Update experiences CSS in `src/css/main.css`**
+
+Replace the `::before` timeline line with a real-element rule. Delete both of these rules:
+
+```css
+.experiences-container::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 3rem;
+  bottom: 12rem;
+  width: 2px;
+  background-color: rgba(255, 255, 255, 0.1);
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform 1s ease;
+}
+.experiences-container.animate-line::before {
+  transform: scaleY(1);
+}
+```
+
+and add in their place:
+
+```css
+.experiences-line {
+  position: absolute;
+  left: 0;
+  top: 3rem;
+  bottom: 12rem;
+  width: 2px;
+  background-color: rgba(255, 255, 255, 0.1);
+  transform-origin: top;
+}
+```
+
+Replace the `.experiences-item` rule with (Motion owns the entrance; CSS owns the hover wash):
+
+```css
+.experiences-item {
+  position: relative;
+  margin-bottom: 0.5rem;
+  border-radius: 8px;
+  transition: background-color 0.3s ease;
+}
+.experiences-item:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+```
+
+Delete these dead rules:
+
+```css
+.experiences-item:nth-child(odd) {
+  animation: none;
+}
+.experiences-item:nth-child(even) {
+  animation: none;
+}
+```
+
+In `.experiences-icon`, delete the hidden-state lines:
+
+```css
+  opacity: 0;
+  transform: scale(0.8);
+  transition:
+    opacity 0.6s ease,
+    transform 0.6s ease;
+```
+
+Delete the rule:
+
+```css
+.experiences-item.animate-icon .experiences-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+```
+
+Replace the `.experiences-content` rule's animation properties — delete:
+
+```css
+  opacity: 0;
+  transform: translateX(20px);
+  transition:
+    opacity 0.6s ease,
+    transform 0.6s ease,
+    all 0.3s ease;
+```
+
+and add in its place:
+
+```css
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+```
+
+Delete these three rules:
+
+```css
+.experiences-item.animate-content .experiences-content {
+  opacity: 1;
+  transform: translateX(0);
+}
+.experiences-item:hover .experiences-content {
+  transform: translateX(0);
+}
+.experiences-item:hover .experiences-icon {
+  transform: scale(1);
+}
+```
+
+and add the editorial nudge:
+
+```css
+.experiences-item:hover .experiences-content {
+  transform: translateX(6px);
+}
+```
+
+In the `@media (max-width: 768px)` block, change the selector `.experiences-container::before` to `.experiences-line` (keep its properties: `left: calc(45px - 1px); top: 1.5rem; bottom: 12rem; width: 2px;`).
+
+In the `@media (max-width: 480px)` block, change the selector `.experiences-container::before` to `.experiences-line` (keep its properties: `left: calc(40px - 1px); top: 1.5rem; bottom: 12rem;`).
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build` → passes.
+Run: `npm run dev`, scroll to Experiences → the line draws downward while items cascade in with blur fade-up, 80ms apart, as one choreographed unit. Hovering a row washes the background and nudges the content right 6px. Check the line position at mobile width (devtools responsive mode).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Experiences.tsx src/css/main.css
+git commit -m "feat: choreograph experiences timeline with motion variants"
+```
+
+---
+
+### Task 6: Migrate Projects to Motion reveals and editorial hovers
+
+**Files:**
+- Modify: `src/components/Projects.tsx` (delete IntersectionObserver-style `useEffect`, `useRef`, `isAnimating`; convert items to Motion)
+- Modify: `src/css/main.css` (project rules, ~lines 519–643, plus duplicated `.project-title-link` rules in media queries)
+
+- [ ] **Step 1: Update `src/components/Projects.tsx`**
+
+Change the first import line from:
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+```
+
+to:
+
+```tsx
+import { useState } from 'react';
+import { motion } from 'motion/react';
+import { blurFadeUp, VIEWPORT_ONCE } from '../motion';
+```
+
+(Keep the `ProjectItem` interface and the entire `projectsData` array unchanged.)
+
+Inside the component, delete these lines:
+
+```tsx
+const projectsRef = useRef<HTMLDivElement>(null);
+const [isAnimating, setIsAnimating] = useState<boolean>(false);
+```
+
+Replace `handleShowMore` with:
+
+```tsx
+const handleShowMore = (): void => {
+  setHasShownMore(true);
+};
+```
+
+Delete the entire `useEffect(() => { ... }, [hasShownMore]);` block (the one that sets inline opacity/transform styles).
+
+In the JSX, change `<div className="projects-list" ref={projectsRef}>` to `<div className="projects-list">`, and change each item from:
+
+```tsx
+{displayedProjects.map(project => (
+  <div key={project.id} className="project-item">
+```
+
+to:
+
+```tsx
+{displayedProjects.map((project, index) => (
+  <motion.div
+    key={project.id}
+    className="project-item"
+    initial="hidden"
+    whileInView="visible"
+    viewport={VIEWPORT_ONCE}
+    variants={blurFadeUp}
+    custom={index < initialProjectsCount ? index * 0.08 : 0}
+  >
+```
+
+closing with `</motion.div>`. The inner markup (icon, content, title link, lists) is unchanged. The `custom` prop gives the first three items a small cascade; items revealed by "Show More" animate individually as they scroll into view with no extra delay.
+
+On the Show More button, remove the `disabled={isAnimating}` prop:
+
+```tsx
+<button className="show-more-btn" onClick={handleShowMore}>
+  <span>Show More Projects</span>
+  <i className="fas fa-chevron-down"></i>
+</button>
+```
+
+- [ ] **Step 2: Update projects CSS in `src/css/main.css`**
+
+Replace the `.project-item` rule (currently has duplicate `transition` declarations and hidden-state styles) with:
+
+```css
+.project-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  padding: 1rem;
+  border-radius: 8px;
+  transition: background-color 0.3s ease;
+}
+.project-item:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+```
+
+Delete the rules:
+
+```css
+.project-item:hover {
+  transform: translateY(-5px);
+}
+.project-item.animate-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+```
+
+In `.project-content`, add the nudge transition — replace:
+
+```css
+.project-content {
+  flex: 1;
+}
+```
+
+with:
+
+```css
+.project-content {
+  flex: 1;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.project-item:hover .project-content {
+  transform: translateX(6px);
+}
+```
+
+Replace the `.project-title-link` rules with an underline-draw:
+
+```css
+.project-title-link {
+  color: #ffffff;
+  text-decoration: none;
+  position: relative;
+}
+.project-title-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background-color: rgba(255, 255, 255, 0.6);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.project-item:hover .project-title-link::after {
+  transform: scaleX(1);
+}
+```
+
+Also delete the duplicated `.project-title-link { ... }` and `.project-title-link:hover { ... }` rules inside **both** the `@media (max-width: 768px)` and `@media (max-width: 480px)` blocks (they would reintroduce the old text-decoration underline).
+
+In `.projects-toggle`, delete these two lines:
+
+```css
+  opacity: 0;
+  animation: fadeIn 0.8s ease forwards 1s;
+```
+
+In `.show-more-btn:hover`, delete these two lines (wash only, no lift):
+
+```css
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+```
+
+Delete the now-unused rule:
+
+```css
+.show-more-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+```
+
+Now that nothing uses it, delete the `@keyframes fadeIn { ... }` block.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build` → passes.
+Run: `npm run dev`, scroll to Projects → first three items cascade in with blur fade-up; hovering washes the row, nudges content, and draws an underline across the title. Click "Show More Projects" → button disappears, additional projects blur-fade in as you scroll down to them. Check at mobile width.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Projects.tsx src/css/main.css
+git commit -m "feat: migrate projects to motion reveals and editorial hovers"
+```
+
+---
+
+### Task 7: Reduced-motion CSS and final sweep
+
+**Files:**
+- Modify: `src/css/main.css` (append media query; verify no orphans)
+
+- [ ] **Step 1: Append a reduced-motion media query at the end of `src/css/main.css`**
+
+```css
+/* REDUCED MOTION */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  .scroll-indicator i {
+    animation: none;
+  }
+  .cursor {
+    animation: none;
+  }
+}
+```
+
+(Motion-driven animations are already handled by `MotionConfig reducedMotion="user"`; this covers the remaining CSS animations.)
+
+- [ ] **Step 2: Sweep for orphans**
+
+Run: `grep -n "slideInLeft\|slideInRight\|fadeIn\|animate-line\|animate-icon\|animate-content\|animate-in\|typing-complete\|isAnimating" src/css/main.css src/components/*.tsx src/App.tsx`
+Expected: no matches. If any remain, delete them per Tasks 4–6.
+
+- [ ] **Step 3: Format and verify**
+
+```bash
+npm run format
+npm run build
+```
+
+Expected: both succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A src
+git commit -m "feat: add reduced-motion support and clean up dead animation code"
+```
+
+---
+
+### Task 8: End-to-end visual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full walkthrough**
+
+Run: `npm run dev` and check, top to bottom:
+
+1. **Load:** cursor blinks instantly, typing completes in ~1s, photo/icons/chevron blur-fade in parallel within ~0.9s. No element waits 2+ seconds.
+2. **Nav:** scroll down → navbar glides up and away; scroll up → glides back.
+3. **About:** content blur-fades up once when scrolled to.
+4. **Experiences:** line draws while items cascade; row hover = wash + 6px nudge.
+5. **Projects:** first three cascade; hover = wash + nudge + underline draw; Show More reveals the rest with blur fade-up as scrolled to.
+6. **Footer:** link color transitions still work.
+7. **Mobile (devtools, 480px/768px):** hamburger menu opens/closes; timeline line is positioned correctly; hero stacks correctly.
+8. **Reduced motion:** enable "Reduce motion" in macOS System Settings → Accessibility → Display, reload → text appears without typing animation, reveals are simple fades, no bounce.
+
+- [ ] **Step 2: Production build check**
+
+```bash
+npm run build && npm run preview
+```
+
+Expected: build succeeds; preview at the printed URL renders identically to dev.
+
+- [ ] **Step 3: Final commit (if any fixes were needed)**
+
+```bash
+git add -A src
+git commit -m "fix: polish animation details from visual verification"
+```
+
+Skip this commit if Step 1 and 2 surfaced nothing.

--- a/docs/superpowers/plans/2026-06-19-projects-hover-animation.md
+++ b/docs/superpowers/plans/2026-06-19-projects-hover-animation.md
@@ -1,0 +1,188 @@
+# Projects Hover Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On project-row hover, draw the title underline left-to-right and give the row a subtle ~3px upward popout, with reduced-motion support.
+
+**Architecture:** Pure CSS changes in `src/css/main.css` only. The title underline becomes an absolutely-positioned `::after` line that animates `scaleX: 0→1`; the row lift is softened. No changes to `Projects.tsx` (markup hooks `.project-item` / `.project-title-link` already exist). No new dependencies.
+
+**Tech Stack:** Plain CSS, Vite build, Prettier. No unit-test framework in this repo — verification is `npm run build`, `npm run format:check`, and a manual visual check in `npm run dev`.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-projects-hover-animation-design.md`
+
+---
+
+### Task 1: Title draw-line + softened popout
+
+**Files:**
+- Modify: `src/css/main.css:531-533` (`.project-item:hover` lift)
+- Modify: `src/css/main.css:594-602` (`.project-title-link` + `:hover`)
+
+- [ ] **Step 1: Soften the row lift**
+
+Replace the `.project-item:hover` block at `src/css/main.css:531-533`:
+
+```css
+.project-item:hover {
+  transform: translateY(-3px);
+}
+```
+
+(Only the `-5px` → `-3px` value changes. No background-color is added.)
+
+- [ ] **Step 2: Convert the title underline to an animated draw-line**
+
+Replace the two blocks at `src/css/main.css:594-602` (`.project-title-link` and `.project-title-link:hover`) with:
+
+```css
+.project-title-link {
+  color: #ffffff;
+  text-decoration: none;
+  position: relative;
+  transition: color 0.3s ease;
+}
+.project-title-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background-color: rgba(255, 255, 255, 0.6);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.project-item:hover .project-title-link::after {
+  transform: scaleX(1);
+}
+.project-title-link:hover {
+  color: #cccccc;
+}
+```
+
+Notes: the draw is triggered by **row** hover (`.project-item:hover .project-title-link::after`), matching the row-level lift. The old static `text-decoration: underline` is gone — the `::after` is now the underline.
+
+- [ ] **Step 3: Build to verify CSS compiles**
+
+Run: `npm run build`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Format check**
+
+Run: `npm run format:check`
+Expected: PASS. If it fails, run `npm run format` and re-run `npm run format:check`.
+
+- [ ] **Step 5: Visual check**
+
+Run: `npm run dev`, open the projects section, hover a project row.
+Expected: the title's underline draws left-to-right (~0.35s) and the row lifts ~3px. Moving the cursor off reverses both smoothly. No background wash appears.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/css/main.css
+git commit -m "feat: animate projects title underline draw and soften hover lift"
+```
+
+---
+
+### Task 2: Resolve mobile-breakpoint overrides
+
+**Files:**
+- Modify: `src/css/main.css:821-824` (mobile `.project-title-link:hover`)
+- Modify: `src/css/main.css:952-955` (mobile `.project-title-link:hover`)
+
+The base draw-line is undone inside two media queries that re-declare `text-decoration: underline` on hover. Remove that static rule so it doesn't fight the base draw-line. (Hover doesn't fire on touch devices, so there is no visible behavior change — this only removes a conflicting rule.)
+
+- [ ] **Step 1: Remove the static underline from the first mobile block**
+
+In the block at `src/css/main.css:821` (`.project-title-link:hover` inside the first media query), delete the `text-decoration: underline;` line so the block reads:
+
+```css
+  .project-title-link:hover {
+    color: #cccccc;
+  }
+```
+
+- [ ] **Step 2: Remove the static underline from the second mobile block**
+
+In the block at `src/css/main.css:952` (`.project-title-link:hover` inside the second media query), delete the `text-decoration: underline;` line so the block reads:
+
+```css
+  .project-title-link:hover {
+    color: #cccccc;
+  }
+```
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Format check**
+
+Run: `npm run format:check`
+Expected: PASS (run `npm run format` first if needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/css/main.css
+git commit -m "fix: drop conflicting static underline in projects mobile breakpoints"
+```
+
+---
+
+### Task 3: Reduced-motion support
+
+**Files:**
+- Modify: `src/css/main.css` (append a new `@media` block at end of file, after line 1049)
+
+`main` has no `prefers-reduced-motion` handling. Add a minimal block scoped to this feature: disable the draw transition (line snaps to full width on hover) and disable the lift.
+
+- [ ] **Step 1: Append the reduced-motion block**
+
+At the end of `src/css/main.css`, append:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .project-title-link::after {
+    transition: none;
+  }
+  .project-item:hover {
+    transform: none;
+  }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Format check**
+
+Run: `npm run format:check`
+Expected: PASS (run `npm run format` first if needed).
+
+- [ ] **Step 4: Visual check with reduced motion**
+
+Enable the OS "Reduce motion" setting (macOS: System Settings → Accessibility → Display → Reduce motion), reload `npm run dev`, hover a project.
+Expected: no row lift; the underline appears at full width without animating.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/css/main.css
+git commit -m "feat: respect reduced-motion for projects hover animation"
+```
+
+---
+
+## Final Verification
+
+- [ ] `npm run build` passes.
+- [ ] `npm run format:check` passes.
+- [ ] `npm run dev`: hovering each of the first three project rows draws the title line and lifts ~3px; after clicking "Show More Projects", newly revealed rows behave identically.
+- [ ] Reduced-motion: no lift, underline non-animated.

--- a/docs/superpowers/specs/2026-06-09-animation-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-09-animation-redesign-design.md
@@ -1,0 +1,51 @@
+# Animation Redesign — Design Spec
+
+**Date:** 2026-06-09
+**Status:** Approved
+
+## Problem
+
+The site's animations feel clunky: long fixed delays (hero image waits 2.25s), default `ease` curves everywhere, mechanical 200ms staggers driven by hand-rolled IntersectionObserver code with inline styles, and no reduced-motion support. The minimalist dark aesthetic is good and stays.
+
+## Goal
+
+Same layout, same content, same dark minimalist palette (`#181818` background, white/gray text). All-new motion system with a **subtle & refined** feel: fast, understated, consistent easing.
+
+## Decisions (validated with visual mockups)
+
+| Question | Decision |
+|---|---|
+| Motion feel | Subtle & refined |
+| Stack | Keep React 18 + Vite, add `motion` library (Framer Motion successor) |
+| Scope | Same layout, new polish — no layout/color/content changes |
+| Hero entrance | Refined typewriter: starts instantly, ~55ms/char, photo + icons fade in parallel |
+| Scroll reveals | Blur fade-up: rise ~14px while sharpening from 6px blur |
+| Hovers | Editorial wash: background brighten + 6px content nudge + underline draw |
+
+## Architecture
+
+**Hybrid animation system:** the `motion` library handles entrances and scroll reveals (orchestration, viewport detection, reduced-motion); hover states stay pure CSS (instant, no JS overhead).
+
+- `src/motion.ts` — shared tokens: one easing curve `cubic-bezier(0.22, 1, 0.36, 1)` used everywhere, `blurFadeUp` / `staggerContainer` / `lineDraw` variants, shared viewport config (`once: true`).
+- `src/components/Reveal.tsx` — wrapper component (`whileInView` + `blurFadeUp`) replacing all four hand-rolled IntersectionObserver implementations.
+- `<MotionConfig reducedMotion="user">` wraps the app; the Hero typewriter checks `useReducedMotion`; a `prefers-reduced-motion` CSS media query covers remaining CSS animations.
+
+## Per-section behavior
+
+**Hero:** Typing starts immediately on load (no 2.25s dead air), ~55ms/char, keeps the blinking cursor and grayscale gradient on "Nathan". Photo, social icons, and scroll indicator blur-fade in parallel with delays of 0.1s / 0.25s / 0.4s. Scroll indicator gets a gentler, slower bounce (−6px, 2.4s, ease-in-out).
+
+**Scroll reveals (About / Experiences / Projects):** opacity 0→1, y 14→0, blur 6px→0, 0.5s, shared easing, triggered once slightly before entering the viewport. Experiences uses one variant tree: container staggers children 80ms apart while the timeline line (now a real `div`, not a `::before`) draws in with `scaleY`. Projects items reveal per-item; the first three get an 80ms cascade. Newly shown projects (after "Show More") reveal the same way as they scroll into view.
+
+**Hovers:** Project and experience rows: background washes to `rgba(255,255,255,0.05)`, content nudges right 6px, underline draws left-to-right across project titles. No more card lifting. Circular social icons: background/border brighten only. Show More button: wash treatment, keeps chevron nudge, loses lift + shadow.
+
+**Navigation:** Keep hide-on-scroll-down behavior; transition becomes `transform 0.45s` with the shared easing curve.
+
+**Cleanup:** Delete `slideInLeft`, `slideInRight`, `fadeIn` keyframes, all per-component IntersectionObserver code, inline-style animation hacks, and the `animate-*` CSS classes.
+
+## Out of scope
+
+Layout changes, color changes, content changes, new sections, framework switch, test framework introduction.
+
+## Verification
+
+`npm run build` passes; `npm run format:check` passes; visual walkthrough of every section via `npm run dev`; reduced-motion check via system setting; mobile hamburger menu still works.

--- a/docs/superpowers/specs/2026-06-19-projects-hover-animation-design.md
+++ b/docs/superpowers/specs/2026-06-19-projects-hover-animation-design.md
@@ -1,0 +1,67 @@
+# Projects Hover Animation — Design Spec
+
+**Date:** 2026-06-19
+**Status:** Approved
+**Branch:** `projects-hover-animation` (off `main`)
+
+## Problem
+
+On `main`, hovering a project row produces two abrupt effects: the whole row jumps up 5px (`translateY(-5px)`), and the title gets a static `text-decoration: underline` plus a color shift that snap on instantly. There's no motion to the underline — it just appears.
+
+The `animation-redesign` branch already proved out a nicer treatment (a title underline that *draws* left-to-right). This spec ports that hover feel back onto `main` as a small, self-contained change, without pulling in the rest of that branch's redesign (no `motion` library, no scroll-reveal changes).
+
+## Goal
+
+When the user hovers a project, the title's underline **draws in left-to-right** and the row gives a **subtle upward popout** (~3px lift). Same layout, same content, same dark palette. Pure CSS — no new dependencies, no component/markup changes.
+
+## Decisions (confirmed with user)
+
+| Question | Decision |
+|---|---|
+| Underline | Animated left-to-right draw via `::after` pseudo-element (replaces static `text-decoration: underline`) |
+| Popout | Subtle vertical lift, `translateY(-3px)` (reduced from main's `-5px`) |
+| Background wash | **Not** included — keep it clean |
+| Scroll reveals | Unchanged from `main` |
+| Stack | Pure CSS only; no `motion` library |
+
+## Implementation
+
+All changes are in `src/css/main.css`. **No changes to `Projects.tsx`** — the markup already has `.project-item` and `.project-title-link` hooks.
+
+### 1. Title draw-line
+
+Replace the current static-underline hover on `.project-title-link`:
+
+- `.project-title-link` gains `position: relative` and keeps `color: #ffffff` with no underline.
+- Add `.project-title-link::after`: an absolutely-positioned 1px line at the bottom of the link, full width, `transform: scaleX(0)` with `transform-origin: left`, transitioning `transform 0.35s cubic-bezier(0.22, 1, 0.36, 1)`.
+- On `.project-item:hover .project-title-link::after` (row-level hover, matching current behavior where hovering anywhere on the row triggers the effect), set `transform: scaleX(1)`.
+- Keep a gentle color lift to `#cccccc` on hover for consistency with the rest of the row; drop the old `text-decoration: underline`.
+
+Line color: `rgba(255, 255, 255, 0.6)` (matches the proven value from `animation-redesign`).
+
+### 2. Row popout
+
+- `.project-item:hover` changes from `transform: translateY(-5px)` to `transform: translateY(-3px)`.
+- No background-color change.
+
+### 3. Mobile overrides
+
+Two media-query blocks currently re-declare `.project-title-link:hover { text-decoration: underline }`. Remove the static `text-decoration: underline` from those so they don't fight the base draw-line. Hover doesn't fire on touch devices, so no visible regression; this just prevents conflicting rules.
+
+### 4. Reduced motion
+
+`main` has no `prefers-reduced-motion` block today. Add a minimal one covering this feature only: inside `@media (prefers-reduced-motion: reduce)`, set `.project-title-link::after { transition: none }` and `.project-item:hover { transform: none }`. Hovering still shows the line (it snaps to full width) and no lift occurs.
+
+## Out of scope
+
+- The `motion` library migration and scroll-reveal rework from `animation-redesign`.
+- Experiences/hero/about/nav animations.
+- Background wash on project rows.
+- Any layout, color-palette, or content change.
+
+## Verification
+
+- `npm run build` passes.
+- `npm run format:check` passes (or `npm run format` applied).
+- `npm run dev` visual check: hovering a project draws the title line left-to-right and lifts the row ~3px; moving off reverses smoothly; works on the first three rows and on rows revealed via "Show More".
+- Reduced-motion check via system setting: no lift, underline appears without animating.

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -835,7 +835,6 @@ h6 {
   }
   .project-title-link:hover {
     color: #cccccc;
-    text-decoration: underline;
   }
   body {
     background-color: #2a2a2a;
@@ -966,7 +965,6 @@ h6 {
   }
   .project-title-link:hover {
     color: #cccccc;
-    text-decoration: underline;
   }
   .experiences-container {
     padding-left: 2rem;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1060,3 +1060,12 @@ h6 {
 .projects {
   padding: 60px 0;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .project-title-link::after {
+    transition: none;
+  }
+  .project-item:hover {
+    transform: none;
+  }
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -529,7 +529,7 @@ h6 {
     transform 0.6s ease;
 }
 .project-item:hover {
-  transform: translateY(-5px);
+  transform: translateY(-3px);
 }
 .project-item.animate-in {
   opacity: 1;
@@ -594,11 +594,26 @@ h6 {
 .project-title-link {
   color: #ffffff;
   text-decoration: none;
+  position: relative;
   transition: color 0.3s ease;
+}
+.project-title-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background-color: rgba(255, 255, 255, 0.6);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.project-item:hover .project-title-link::after {
+  transform: scaleX(1);
 }
 .project-title-link:hover {
   color: #cccccc;
-  text-decoration: underline;
 }
 .projects-toggle {
   display: flex;


### PR DESCRIPTION
## Summary
- Project title underline now **draws left-to-right** on row hover (`::after`, `scaleX: 0→1`, 0.35s eased) instead of snapping on as a static `text-decoration: underline`
- Softened the row hover popout from `translateY(-5px)` to `-3px`; no background wash added
- Removed the conflicting static `text-decoration: underline` from the two mobile breakpoint overrides
- Added a scoped `prefers-reduced-motion` block (no lift, underline appears without animating)

Pure CSS in `src/css/main.css`; `Projects.tsx` and scroll-in reveals are unchanged. Ports the proven hover treatment from the `animation-redesign` branch without pulling in the `motion` library. Spec and plan included under `docs/superpowers/`.

## Test Plan
- [x] `npm run build` passes
- [x] `npm run format:check` passes
- [ ] `npm run dev`: hovering each project draws the title line and lifts ~3px; reverses smoothly on mouse-out
- [ ] After "Show More Projects", newly revealed rows behave identically
- [ ] OS "Reduce motion" enabled: no lift, underline non-animated

🤖 Generated with [Claude Code](https://claude.com/claude-code)